### PR TITLE
ARC4: add in-place variant

### DIFF
--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -267,6 +267,8 @@ module Cipher_stream : sig
     type key
     type result = { message : Cstruct.t ; key : key }
     val of_secret : Cstruct.t -> key
+    val encrypt_into : key:key -> Cstruct.t -> Cstruct.t -> key
+    val decrypt_into : key:key -> Cstruct.t -> Cstruct.t -> key
     val encrypt : key:key -> Cstruct.t -> result
     val decrypt : key:key -> Cstruct.t -> result
   end


### PR DESCRIPTION
Allow to pass an output buffer (possibly equal to the input buffer) to do ARC4 encoding/decoding.  In my use case (BitTorrent) this cipher is applied to large amount of data and doing it in-place has a rather positive impact in memory consumption (in part because Cstruct's are not compacted by the GC).
