### PR TITLE
require mirage-xen in at least 2.2.0, otherwise travis installs an

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -25,7 +25,7 @@ ocaml setup.ml -test
 
 # check Xen support builds too
 set -eu
-if opam install mirage-xen; then
+if opam install "mirage-xen>=2.2.0"; then
   ./configure --enable-xen
   make
   ls -l _build/xen/dllnocrypto_xen_stubs.so

--- a/opam
+++ b/opam
@@ -28,5 +28,9 @@ depopts: [
   "mirage-xen"
 ]
 
+conflicts: [
+  "mirage-xen" {<"2.2.0"}
+]
+
 tags: [ "org:mirage"]
 available: [ ocaml-version >= "4.01.0" ]


### PR DESCRIPTION
ancient version which does not include pkg_config packages