### PR TITLE
depend on the new zarith-xen package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - PACKAGE="nocrypto" OCAML_VERSION=4.01 EXTRA_REMOTES=https://github.com/mirage/mirage-dev.git
-  - PACKAGE="nocrypto" OCAML_VERSION=latest DEPOPTS=lwt EXTRA_REMOTES=https://github.com/mirage/mirage-dev.git
-  - PACKAGE="nocrypto" OCAML_VERSION=latest UPDATE_GCC_BINUTILS=1 DEPOPTS=mirage-xen EXTRA_REMOTES=https://github.com/mirage/mirage-dev.git
+  - PACKAGE="nocrypto" OCAML_VERSION=4.01
+  - PACKAGE="nocrypto" OCAML_VERSION=latest DEPOPTS=lwt
+  - PACKAGE="nocrypto" OCAML_VERSION=latest UPDATE_GCC_BINUTILS=1 DEPOPTS=mirage-xen
 notifications:
   email: false

--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ depends: [
   "type_conv"
   "sexplib"
   "ctypes" {>= "0.3.3"}
-  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen"))
+  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen" & "zarith-xen"))
   "ounit" {test}
 ]
 


### PR DESCRIPTION
zarith-xen has been introduced in opam-repository to avoid cluttering the zarith package up with xen things. in opam-repository, nocrypto already depends on zarith-xen. 