### PR TITLE
Base64.is_base64_char is true if [A-Za-z0-9\+\/]

### DIFF
--- a/src/base64.ml
+++ b/src/base64.ml
@@ -79,6 +79,6 @@ let decode cs =
 
 
 let is_base64_char c =
-  try ( ignore @@ emap (int_of_char c) ; true )
+  try ( ignore @@ dmap (int_of_char c) ; true )
   with Not_found -> false
 


### PR DESCRIPTION
Currently

    List.filter Nocrypto.Base64.is_base64_char (explode sym)

where sym is the string in base64.ml only returns 0-9,+,/ because they have ascii values below 64. I suspect the intended functionality was char -> bool depending on if the char is alphanumeric, +, or / which is what this change does. 