### PR TITLE
only conditionally define __unused, some systems already have this

### DIFF
--- a/src/native/nocrypto.h
+++ b/src/native/nocrypto.h
@@ -21,7 +21,9 @@
 #define NC_AES_GENERIC
 #endif
 
+#ifndef __unused
 #define __unused(x) x __attribute__((unused))
+#endif
 #define __unit() value __unused(unit)
 
 typedef unsigned long u_long;


### PR DESCRIPTION
definition (e.g. in sys/cdefs.h)