### PR TITLE
do not require updates of GCC and binutils anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - PACKAGE="nocrypto" UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.01
-  - PACKAGE="nocrypto" UPDATE_GCC_BINUTILS=1 OCAML_VERSION=latest DEPOPTS=lwt
+  - PACKAGE="nocrypto" OCAML_VERSION=4.01
+  - PACKAGE="nocrypto" OCAML_VERSION=latest DEPOPTS=lwt
   - PACKAGE="nocrypto" UPDATE_GCC_BINUTILS=1 OCAML_VERSION=latest DEPOPTS=mirage-xen
 notifications:
   email: false


### PR DESCRIPTION
still required for the xen scenario, where mirage-entropy-xen is installed... but the other builds don't need it anymore!