### PR TITLE
entropy renaming

### DIFF
--- a/xen/nocrypto_entropy_xen.ml
+++ b/xen/nocrypto_entropy_xen.ml
@@ -3,7 +3,7 @@ open Lwt
 open Nocrypto
 open Uncommon
 
-module E = Entropy_xen
+module E = Entropy
 
 type t = { e : E.t ; token : E.token ; g : Rng.g }
 

--- a/xen/nocrypto_entropy_xen.mli
+++ b/xen/nocrypto_entropy_xen.mli
@@ -17,9 +17,9 @@ val initialize : unit -> unit Lwt.t
 
 (** {1 Interface to Mirage Entropy} *)
 
-val sources : unit -> Entropy_xen.source list option
-(** {!Entropy_xen.source}s set up with the last {{!initialize}initialize}. *)
+val sources : unit -> Entropy.source list option
+(** {!Entropy.source}s set up with the last {{!initialize}initialize}. *)
 
-val attach : Entropy_xen.t -> Nocrypto.Rng.g -> Entropy_xen.token Lwt.t
+val attach : Entropy.t -> Nocrypto.Rng.g -> Entropy.token Lwt.t
 (** [attach e g] starts seeding [g] from the entropy provider [e] and returns
     the token to stop the seeding. *)


### PR DESCRIPTION
in preparation of solo5 support: minimise the pieces using `xen`.  goes well with https://github.com/mirage/mirage-entropy/pull/29