### PR TITLE
MirageOS RANDOM module type requires RNG to have a buffer type

### DIFF
--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -631,6 +631,9 @@ module Rng : sig
     let (a, b) = (arr.(i), arr.(j)) in
     arr.(i) <- b ; arr.(j) <- a ]}
       *)
+
+  type buffer = Cstruct.t
+  (** Type definition to satisfy MirageOS RANDOM signature *)
 end
 
 

--- a/src/rng.ml
+++ b/src/rng.ml
@@ -156,3 +156,5 @@ module Generators = struct
   end
 
 end
+
+type buffer = Cstruct.t


### PR DESCRIPTION
this buffer type does not hurt, and will make Nocrypto.Rng an implementation of `V1_LWT.RANDOM` in the future.