### PR TITLE
Add hmacv

### DIFF
--- a/src/hash.ml
+++ b/src/hash.ml
@@ -12,7 +12,8 @@ module type S = sig
 
   val digest  : Cstruct.t      -> Cstruct.t
   val digestv : Cstruct.t list -> Cstruct.t
-  val hmac    : key:Cstruct.t -> Cstruct.t -> Cstruct.t
+  val hmac    : key:Cstruct.t -> Cstruct.t      -> Cstruct.t
+  val hmacv   : key:Cstruct.t -> Cstruct.t list -> Cstruct.t
 end
 
 module type Foreign = sig
@@ -77,6 +78,12 @@ module Hash_of (F : Foreign) (D : Desc) = struct
     let outer = xor key opad
     and inner = xor key ipad in
     digestv [ outer ; digestv [ inner ; message ] ]
+
+  let hmacv ~key messages =
+    let key = norm key in
+    let outer = xor key opad
+    and inner = xor key ipad in
+    digestv [ outer ; digestv (inner :: messages) ]
 end
 
 module MD5 = Hash_of (Native.MD5) ( struct

--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -193,6 +193,11 @@ module Hash : sig
     (** [hmac ~key bytes] is authentication code for [bytes] under the secret
         [key], generated using the standard HMAC construction over this hash
         algorithm. *)
+
+    val hmacv : key:Cstruct.t -> Cstruct.t list -> Cstruct.t
+    (** [hmac ~key bytesv] is authentication code for [bytesv] under the secret
+        [key], generated using the standard HMAC construction over this hash
+        algorithm. *)
   end
 
   module MD5     : S


### PR DESCRIPTION
This is more efficient than first concatenating everything to one big cstruct.

```ocaml
hmac ~key (Cstruct.concat (messages))
```
vs
```ocaml
hmacv ~key messages
```