### PR TITLE
Fix overflow in Counter.add16.

### DIFF
--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -118,8 +118,7 @@ module Counter = struct
   let add8 cs i x =
     BE.(set_uint64 cs i (Int64.add x (get_uint64 cs i)))
 
-  (* FIXME: overflow: higher order bits. *)
-  let add16 cs i x = add8 cs (i + 8) x
+  let add16 cs i x = Native.add16be cs.buffer i x
 
 end
 

--- a/src/native.ml
+++ b/src/native.ml
@@ -79,5 +79,6 @@ external xor_into : buffer -> off -> buffer -> off -> size -> unit = "caml_nc_xo
 
 external count8be  : buffer -> off -> buffer -> off -> size -> unit = "caml_nc_count_8_be" [@@noalloc]
 external count16be : buffer -> off -> buffer -> off -> size -> unit = "caml_nc_count_16_be" [@@noalloc]
+external add16be : buffer -> off -> int64 -> unit = "caml_nc_add_16_be" [@@noalloc]
 
 external blit : buffer -> off -> buffer -> off -> size -> unit = "caml_blit_bigstring_to_bigstring" [@@noalloc]

--- a/src/native/misc.c
+++ b/src/native/misc.c
@@ -48,6 +48,16 @@ static inline void nc_count_16_be (uint64_t *init, uint64_t *dst, size_t blocks)
   }
 }
 
+static inline void nc_add_16_be (uint64_t *init, uint64_t n) {
+  uint64_t h = be64_to_cpu (init[0]);
+  uint64_t l = be64_to_cpu (init[1]);
+  uint64_t nl = l + n;		/* let it wrap */
+
+  if (nl < l)
+	  h++;
+  init[0] = cpu_to_be64 (h);
+  init[1] = cpu_to_be64 (nl);
+}
 
 CAMLprim value
 caml_nc_xor_into (value b1, value off1, value b2, value off2, value n) {
@@ -68,5 +78,11 @@ caml_nc_count_16_be (value init, value off1, value dst, value off2, value blocks
   nc_count_16_be ( (uint64_t *) _ba_uint8_off (init, off1),
                    (uint64_t *) _ba_uint8_off (dst, off2),
                    Long_val (blocks) );
+  return Val_unit;
+}
+
+CAMLprim value
+caml_nc_add_16_be (value init, value off, value n) {
+  nc_add_16_be ( (uint64_t *) _ba_uint8_off (init, off), Int64_val(n));
   return Val_unit;
 }


### PR DESCRIPTION
I wrote in C since doing the addition with Int64.t and then an unsigned
comparison in ocaml adds a lot of clutter to the code.

As there was precedence in misc.c with caml_nc_count_16_be this seemed like the
right approach.

I'm implementing SSH and it uses the whole 128 bits as the counter in AES-CTR,
so I can expect this to overflow at some point since the initial IV can be
anything.

Maybe there is a easy-peasy-small-cool way to do this in ocaml but my attempt added 5-6lines.