### PR TITLE
Implement RSASSA-PKCS1-V1_5-SIGN/VERIFY with EMSA-PKCS1-v1.5-ENCODE

### DIFF
--- a/src/hash.ml
+++ b/src/hash.ml
@@ -7,6 +7,7 @@ module type S = sig
   val digest_size : int
 
   val init : unit -> t
+  val dup  : t    -> t
   val feed : t    -> Cstruct.t -> unit
   val get  : t    -> Cstruct.t
 
@@ -42,6 +43,11 @@ module Core (F : Foreign) (D : Desc) = struct
   let init () =
     let t = Native.buffer ctx_size in
     ( F.init t ; t )
+
+  let dup ctx =
+    let ctx' = Native.buffer ctx_size in
+    Bigarray.Array1.blit ctx ctx' ;
+    ctx'
 
   let feed t { Cstruct.buffer ; off ; len } =
     F.update t buffer off len

--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -177,6 +177,9 @@ module Hash : sig
     val init : unit -> t
     (** Create a new hash state. *)
 
+    val dup : t -> t
+    (** Create a deep copy of a hash state. *)
+
     val feed : t -> Cstruct.t -> unit
     (** Hash the input, updating the state. *)
 

--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -733,9 +733,7 @@ module Rsa : sig
 
       type t
       (** An initialized hash state that enables signing or verifying large
-        messages that may not fit in memory through the use of [feed t chunk].
-        Be aware that the [sign_t] and [verify_t] functions finalize the hash state, making it illegal to read out using [Hash.S.get], or to call the signing/verifying functions multiple times.
-       *)
+        messages that may not fit in memory through the use of [feed t chunk].*)
 
       val minimum_key_bits : int
       (** The minimum size of keys that can work with this signature type *)
@@ -753,7 +751,7 @@ module Rsa : sig
 
       val sign_t : ?mask:mask -> key:priv -> t -> Cstruct.t
       (** [sign_t key t] is the RSASSA-PKCS1-V1_5 signature on [t] signed by the [key].
-          NOTE: [t] will be in an illegal state after signing, and must not be used again.
+          NOTE: [t] will still be in a legal state since Hash.S.dup is used to copy the state.
           @raise Insufficient_key (see {{!Insufficient_key}Insufficient_key}) *)
 
       val sign : ?mask:mask -> key:priv -> Cstruct.t -> Cstruct.t
@@ -766,7 +764,7 @@ module Rsa : sig
 
       val verify_t : key:pub -> t -> Cstruct.t -> bool
       (** [verify_t key t signature] verifies that [signature] is the RSASSA-PKCS1 V1_5 signature on the data hashed in [t], signed by [key].
-          NOTE: [t] will be in an illegal state after verifying, and must not be used again. *)
+          NOTE: [t] will still be in a legal state since Hash.S.dup is used to copy the state. *)
 
       val verify : key:pub -> msg:Cstruct.t -> Cstruct.t -> bool
       (** [verify key msg signature] verifies that [signature] is the RSASSA-PKCS1 V1_5 signature on [msg], signed by [key]. *)

--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -727,6 +727,42 @@ module Rsa : sig
       Keys must have a minimum of [11 + len(message)] bytes. *)
   module PKCS1 : sig
 
+    module type S = sig
+      (* RFC3477-compliant RSASSA-PKCS1-v1_5-SIGN and RSASSA-PKCS1-v1_5-VERIFY
+         operating with PKCS1 (type 1)-padded signatures *)
+
+      type t
+      (** An initialized hash state that enables signing or verifying large
+        messages that may not fit in memory through the use of [feed t chunk]. *)
+
+      val minimum_key_bits : int
+      (** The minimum size of keys that can work with this signature type *)
+
+      val feed : t -> Cstruct.t -> unit
+      (** [feed t data] updates the internal state [t] with [data] *)
+
+      val sign_t : ?mask:mask -> key:priv -> t -> Cstruct.t
+      (** [sign key t] is the PKCS1-padded (type 1) digest [t]
+          signed by the [key]. *)
+
+      val sign : ?mask:mask -> key:priv -> Cstruct.t -> Cstruct.t
+      (** [sign key msg] is the PKCS1-padded (type 1) hash of [msg]
+          signed by the [key]. *)
+
+      val verify_t : key:pub -> t -> Cstruct.t -> bool
+      (** [verify_t key t signature] verifies that signed PKCS1 (type 1) message *)
+
+      val verify : key:pub -> msg:Cstruct.t -> Cstruct.t -> bool
+      (** [verify key msg signature] verifies that [signature] is a signature on [msg] signed with the private part of [key] *)
+    end
+
+    module MD5 : S
+    module SHA1 : S
+    module SHA224 : S
+    module SHA256 : S
+    module SHA384 : S
+    module SHA512 : S
+
     val sig_encode : ?mask:mask -> key:priv -> Cstruct.t -> Cstruct.t
     (** [sig_encode mask key message] is the PKCS1-padded (type 1) [message]
         signed by the [key]. Note that this operation performs only the padding

--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -741,19 +741,25 @@ module Rsa : sig
       val feed : t -> Cstruct.t -> unit
       (** [feed t data] updates the internal state [t] with [data] *)
 
+      val sign_cs : ?mask:mask -> key:priv -> digest:Cstruct.t -> Cstruct.t
+      (** [sign_cs key digest] is PKCS1-padded (type 1) signature on [digest] signed by the [key]. *)
+
       val sign_t : ?mask:mask -> key:priv -> t -> Cstruct.t
-      (** [sign key t] is the PKCS1-padded (type 1) digest [t]
+      (** [sign_t key t] is the PKCS1-padded (type 1) signature on [t]
           signed by the [key]. *)
 
       val sign : ?mask:mask -> key:priv -> Cstruct.t -> Cstruct.t
       (** [sign key msg] is the PKCS1-padded (type 1) hash of [msg]
           signed by the [key]. *)
 
+      val verify_cs : key:pub -> digest:Cstruct.t -> Cstruct.t -> bool
+      (** [verify_t key digest signature] verifies that [signature] is the PKCS1 (type 1) signature on the data hashed in [digest]*)
+
       val verify_t : key:pub -> t -> Cstruct.t -> bool
-      (** [verify_t key t signature] verifies that signed PKCS1 (type 1) message *)
+      (** [verify_t key t signature] verifies that [signature] is the PKCS1 (type 1) signature on the data hashed in [t] *)
 
       val verify : key:pub -> msg:Cstruct.t -> Cstruct.t -> bool
-      (** [verify key msg signature] verifies that [signature] is a signature on [msg] signed with the private part of [key] *)
+      (** [verify key msg signature] verifies that [signature] is a PKCS1 (type 1) signature on [msg] signed with the private part of [key] *)
     end
 
     module MD5 : S

--- a/src/rsa.ml
+++ b/src/rsa.ml
@@ -174,8 +174,7 @@ module PKCS1 = struct
         Cstruct.(append asn_stub digest)
 
     let sign_t ?mask ~key state =
-      (* TODO use H.dup from https://github.com/mirleft/ocaml-nocrypto/pull/125 *)
-      sign_cs ?mask ~key ~digest:(H.get state)
+      sign_cs ?mask ~key ~digest:(H.dup state |> H.get)
 
     let sign ?mask ~key msg =
       let state = init () in
@@ -192,8 +191,7 @@ module PKCS1 = struct
           Cstruct.equal target untrusted_digest
 
     let verify_t ~key state signature =
-      (* TODO use H.dup from https://github.com/mirleft/ocaml-nocrypto/pull/125 *)
-      verify_cs ~key ~digest:(H.get state) signature
+      verify_cs ~key ~digest:(H.dup state |> H.get) signature
 
     let verify ~key ~msg signature =
       let state = init () in

--- a/src/rsa.ml
+++ b/src/rsa.ml
@@ -143,6 +143,7 @@ module PKCS1 = struct
   module type S = sig
     type t
     val minimum_key_bits : int
+    val init : unit -> t
     val feed : t -> Cstruct.t -> unit
     val sign_cs : ?mask:mask -> key:priv -> digest:Cstruct.t -> Cstruct.t
     val sign_t : ?mask:mask -> key:priv -> t -> Cstruct.t
@@ -152,24 +153,33 @@ module PKCS1 = struct
     val verify : key:pub -> msg:Cstruct.t -> Cstruct.t -> bool
   end
 
-  module Make(Parameters : (sig val asn_stub : Cstruct.t module H : Hash.S end)) : S = struct
-    type t = Parameters.H.t
-    (* see [val padded] above, don't understand how the rounding down stuff works, but oh well: *)
-    let minimum_key_bits = (8 * Parameters.H.digest_size) + (8 * min_pad) + (8 * Cstruct.len Parameters.asn_stub) - 7
+  module Make (H:Hash.S) (Parameter : sig val asn_stub : Cstruct.t end)
+    : S with type t = H.t = struct
 
-    let feed = Parameters.H.feed
+    open Parameter
+    type t = H.t
+
+    let minimum_key_bits =
+      (* TODO see [val padded] above, don't understand how the rounding down stuff works, but oh well: *)
+      (8 * H.digest_size) + (8 * min_pad) + (8 * Cstruct.len asn_stub) - 7
+
+    let init = H.init
+    let feed = H.feed
 
     let sign_cs ?mask ~key ~digest =
       (* padded does step 4-5 of EMSA-PKCS1-v1_5-ENCODE below: *)
-      padded pad_01 (decrypt ?mask ~key) (priv_bits key) Cstruct.(append Parameters.asn_stub digest)
+      if priv_bits key < minimum_key_bits
+      then raise Insufficient_key ;
+      padded pad_01 (decrypt ?mask ~key) (priv_bits key)
+        Cstruct.(append asn_stub digest)
 
     let sign_t ?mask ~key state =
-      let digest = Parameters.H.get state in
-      sign_cs ?mask ~key ~digest
+      (* TODO use H.dup from https://github.com/mirleft/ocaml-nocrypto/pull/125 *)
+      sign_cs ?mask ~key ~digest:(H.get state)
 
     let sign ?mask ~key msg =
-      let state = Parameters.H.init () in
-      let () = Parameters.H.feed state msg in
+      let state = init () in
+      let () = feed state msg in
       sign_t ?mask ~key state
 
     let verify_cs ~key ~digest signature =
@@ -178,15 +188,16 @@ module PKCS1 = struct
       with
       | None -> false
       | Some untrusted_digest ->
-          let target = Cstruct.append Parameters.asn_stub digest in
+          let target = Cstruct.append asn_stub digest in
           Cstruct.equal target untrusted_digest
 
     let verify_t ~key state signature =
-      verify_cs ~key ~digest:(Parameters.H.get state) signature
+      (* TODO use H.dup from https://github.com/mirleft/ocaml-nocrypto/pull/125 *)
+      verify_cs ~key ~digest:(H.get state) signature
 
     let verify ~key ~msg signature =
-      let state = Parameters.H.init () in
-      let () = Parameters.H.feed state msg in
+      let state = init () in
+      let () = feed state msg in
       verify_t ~key state signature
 
   end
@@ -198,29 +209,27 @@ module PKCS1 = struct
      You can verify with something like (ignoring the last Hash.S.digest_size bytes):
      X509.Encoding.pkcs1_digest_info_to_cstruct (`SHA256, Hash.SHA256.(digest Cstruct.(of_string "b")))
   *)
-  module MD5 = Make (struct module H = Hash.MD5
-                      let asn_stub = Cstruct.of_string "\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10"
-                      end)
+  module MD5 = Make (Hash.MD5)(struct
+    let asn_stub = Cstruct.of_string "\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10" end)
 
-  module SHA1 = Make (struct module H = Hash.SHA1
-                      let asn_stub = Cstruct.of_string "\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14"
-                      end)
+  module SHA1 = Make (Hash.SHA1)(struct
+    let asn_stub = Cstruct.of_string "\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14" end)
 
-  module SHA224 = Make (struct module H = Hash.SHA1
-                      let asn_stub = Cstruct.of_string "\x30\x2d\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x04\x05\x00\x04\x1c"
-                      end)
+  module SHA224 = Make (Hash.SHA224)(struct
+    let asn_stub = Cstruct.of_string "\x30\x2d\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x04\x05\x00\x04\x1c" end)
 
-  module SHA384 = Make (struct module H = Hash.SHA1
-                      let asn_stub = Cstruct.of_string "\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30"
-                      end)
+  module SHA384 = Make (Hash.SHA384)(struct
+    let asn_stub = Cstruct.of_string "\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30" end)
 
-  module SHA256 = Make (struct module H = Hash.SHA256
-                      let asn_stub = Cstruct.of_string "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20"
-                      end)
+  module SHA256 = Make (Hash.SHA256)(struct
+    let asn_stub = Cstruct.of_string "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20" end)
 
-  module SHA512 = Make (struct module H = Hash.SHA512
-                      let asn_stub = Cstruct.of_string "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40"
-                      end)
+  module SHA512 = Make (Hash.SHA512)(struct
+    let asn_stub = Cstruct.of_string "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40" end)
+
+  (* SHA512/256 (currently not in Nocrypto.Hash.): module SHA512_256 = Make(Hash.SHA512_256)(struct
+let asn_stub = "31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x06\x05\x00\x04\x20" end)
+*)
 
   let sig_encode ?mask ~key msg =
     padded pad_01 (decrypt ?mask ~key) (priv_bits key) msg

--- a/tests/testlib.ml
+++ b/tests/testlib.ml
@@ -209,6 +209,32 @@ let rsa_pkcs1_sign_selftest ~bits n =
     assert_bool ("verification failure (SHA512) " ^ show_key_size key)
     Rsa.(P.verify ~key:(pub_of_priv key) ~msg sgn_sha512)
 
+let rsa_pkcs1_sign_cases () =
+  (* generated with the python-crypto module:
+     from Crypto.Hash import SHA
+     from Crypto.PublicKey import RSA
+     from Crypto.Signature import PKCS1_v1_5
+     msg = 'Hello world'
+     print 'let msg = Cstruct.of_string "'+msg+'" in\n'
+     hash = SHA.new(msg)
+     key = RSA.generate(1024)
+     def to_z(n):
+       return 'Z.(of_string_base 16 "' + hex(n)[2:-1] + '")'
+     print 'let key = Nocrypto.Rsa.priv_of_primes ~e:', to_z(key.e), '~p:', to_z(key.p), '~q:', to_z(key.q), ' in\n'
+     signature = PKCS1_v1_5.new(key).sign(hash)
+     print 'let sign = match Nocrypto.Base64.decode Cstruct.(of_string "'+signature.encode('base64').replace('\n','')+'") with Some x -> x in\n'
+     print 'Nocrypto.Rsa.PKCS1.SHA1.verify ~key:Rsa.(pub_of_priv key) ~msg sign;;'
+  *)
+  "cases" >:: times ~n:1 @@ fun _ ->
+  let msg = Cstruct.of_string "Hello world" in
+  let key = Nocrypto.Rsa.priv_of_primes ~e: Z.(of_string_base 16 "10001") ~p:Z.(of_string_base 16 "b6e019bbafab9aadef8a525d37141660f43fe7fb8a2a9cc9510fd6c419a2af40d2cc699d5a6b49b9775a01d89714ce348e1f0ee5c4394f5010ee144278e23401") ~q:Z.(of_string_base 16 "cfaa680f61633c35f38394c2204361c1ff64c52d166d1a7ab85186b5b2785e92ee420e87df3c353710332b096b29fa0de9115d4064fd8c5ab9637b6793173017")  in
+  match Nocrypto.Base64.decode Cstruct.(of_string "kNNHPAQkSTbn8j+UtCZkNirTTvedGiUhJlztd9pcvoBH0xpGyuAmA4xhwwNa4KxYYPHI+g48XiTT10QRR1tFKfT2OiQmC77aVVvoNABeObrdt5eZVKE9BBH76t758GiI3eJWYlKnwFRqjLQIXOJYJ6DrDU/I16Zg3KLuSShoaUE=") with
+  | None -> assert_failure "base64 decoding failed"
+  | Some python_signature ->
+  let our_signature = Nocrypto.Rsa.PKCS1.SHA1.sign ~key msg in
+  assert_bool "Verification failed (python-crypto, sha1, 1024-bit key)"
+  @@ Nocrypto.Rsa.PKCS1.SHA1.verify ~key:Rsa.(pub_of_priv key) ~msg python_signature
+  ; assert_cs_equal ~msg:"Our PKCS1 signature <> python-crypto's using the same parameters" python_signature our_signature
 
 let rsa_pkcs1_encrypt_selftest ~bits n =
   "selftest" >:: times ~n @@ fun _ ->
@@ -920,10 +946,11 @@ let suite =
     "RSA-PKCS1-SIGN" >::: [
       rsa_pkcs1_sign_selftest ~bits:111 100 ;
       rsa_pkcs1_sign_selftest ~bits:256 10 ;
-      rsa_pkcs1_sign_selftest ~bits:744 5 ;
+      rsa_pkcs1_sign_selftest ~bits:744 10 ;
       rsa_pkcs1_sign_selftest ~bits:745 10 ;
       rsa_pkcs1_sign_selftest ~bits:751 10 ;
       rsa_pkcs1_sign_selftest ~bits:752 10 ;
+      rsa_pkcs1_sign_cases () ;
     ] ;
 
     "RSA-OAEP(SHA1)-ENC" >::: [

--- a/tests/testlib.ml
+++ b/tests/testlib.ml
@@ -201,13 +201,16 @@ let rsa_pkcs1_sign_selftest ~bits n =
     let module P = Rsa.PKCS1.SHA512 in
     let signop = fun () -> P.sign ~key msg in
     if bits < P.minimum_key_bits then
-      assert_raises ~msg:("fails to reject keys of size " ^(string_of_int bits)^ " below min size " ^ (string_of_int P.minimum_key_bits)) Rsa.Insufficient_key signop
+      assert_raises ~msg:("fails to reject keys of size " ^(string_of_int bits)
+                      ^ " below min size " ^ (string_of_int P.minimum_key_bits))
+        Rsa.Insufficient_key signop
     else
     match signop () with
-    | exception Rsa.Insufficient_key -> assert_failure ("Unexpected Insufficient_key raised: " ^ show_key_size key)
+      | exception Rsa.Insufficient_key ->
+        assert_failure ("Unexpected Insufficient_key raised: " ^ show_key_size key)
     | sgn_sha512 ->
-    assert_bool ("verification failure (SHA512) " ^ show_key_size key)
-    Rsa.(P.verify ~key:(pub_of_priv key) ~msg sgn_sha512)
+      assert_bool ("verification failure (SHA512) " ^ show_key_size key)
+        Rsa.(P.verify ~key:(pub_of_priv key) ~msg sgn_sha512)
 
 let rsa_pkcs1_sign_cases () =
   (* generated with the python-crypto module:
@@ -227,14 +230,20 @@ let rsa_pkcs1_sign_cases () =
   *)
   "cases" >:: times ~n:1 @@ fun _ ->
   let msg = Cstruct.of_string "Hello world" in
-  let key = Nocrypto.Rsa.priv_of_primes ~e: Z.(of_string_base 16 "10001") ~p:Z.(of_string_base 16 "b6e019bbafab9aadef8a525d37141660f43fe7fb8a2a9cc9510fd6c419a2af40d2cc699d5a6b49b9775a01d89714ce348e1f0ee5c4394f5010ee144278e23401") ~q:Z.(of_string_base 16 "cfaa680f61633c35f38394c2204361c1ff64c52d166d1a7ab85186b5b2785e92ee420e87df3c353710332b096b29fa0de9115d4064fd8c5ab9637b6793173017")  in
-  match Nocrypto.Base64.decode Cstruct.(of_string "kNNHPAQkSTbn8j+UtCZkNirTTvedGiUhJlztd9pcvoBH0xpGyuAmA4xhwwNa4KxYYPHI+g48XiTT10QRR1tFKfT2OiQmC77aVVvoNABeObrdt5eZVKE9BBH76t758GiI3eJWYlKnwFRqjLQIXOJYJ6DrDU/I16Zg3KLuSShoaUE=") with
+  let key = Nocrypto.Rsa.priv_of_primes ~e: Z.(of_string_base 16 "10001")
+      ~p:Z.(of_string_base 16 "b6e019bbafab9aadef8a525d37141660f43fe7fb8a2a9cc9510fd6c419a2af40d2cc699d5a6b49b9775a01d89714ce348e1f0ee5c4394f5010ee144278e23401")
+      ~q:Z.(of_string_base 16 "cfaa680f61633c35f38394c2204361c1ff64c52d166d1a7ab85186b5b2785e92ee420e87df3c353710332b096b29fa0de9115d4064fd8c5ab9637b6793173017") in
+  match Nocrypto.Base64.decode
+          Cstruct.(of_string "kNNHPAQkSTbn8j+UtCZkNirTTvedGiUhJlztd9pcvoBH0xpGyuAmA4xhwwNa4KxYYPHI+g48XiTT10QRR1tFKfT2OiQmC77aVVvoNABeObrdt5eZVKE9BBH76t758GiI3eJWYlKnwFRqjLQIXOJYJ6DrDU/I16Zg3KLuSShoaUE=") with
   | None -> assert_failure "base64 decoding failed"
   | Some python_signature ->
   let our_signature = Nocrypto.Rsa.PKCS1.SHA1.sign ~key msg in
   assert_bool "Verification failed (python-crypto, sha1, 1024-bit key)"
-  @@ Nocrypto.Rsa.PKCS1.SHA1.verify ~key:Rsa.(pub_of_priv key) ~msg python_signature
-  ; assert_cs_equal ~msg:"Our PKCS1 signature <> python-crypto's using the same parameters" python_signature our_signature
+  @@ Nocrypto.Rsa.PKCS1.SHA1.verify ~key:Rsa.(pub_of_priv key)
+    ~msg python_signature ;
+  assert_cs_equal
+    ~msg:"Our PKCS1 signature <> python-crypto's using the same parameters"
+    python_signature our_signature
 
 let rsa_pkcs1_encrypt_selftest ~bits n =
   "selftest" >:: times ~n @@ fun _ ->


### PR DESCRIPTION
I had a go at this since I need it, open to suggestions or refactoring.

Addresses https://github.com/mirleft/ocaml-nocrypto/issues/119