### PR TITLE
implement Hash.dup which copies the hash state

### DIFF
--- a/src/hash.ml
+++ b/src/hash.ml
@@ -7,6 +7,7 @@ module type S = sig
   val digest_size : int
 
   val init : unit -> t
+  val dup  : t    -> t
   val feed : t    -> Cstruct.t -> unit
   val get  : t    -> Cstruct.t
 
@@ -42,6 +43,11 @@ module Core (F : Foreign) (D : Desc) = struct
   let init () =
     let t = Native.buffer ctx_size in
     ( F.init t ; t )
+
+  let dup ctx =
+    let ctx' = Native.buffer ctx_size in
+    Bigarray.Array1.blit ctx ctx' ;
+    ctx'
 
   let feed t { Cstruct.buffer ; off ; len } =
     F.update t buffer off len

--- a/src/nocrypto.mli
+++ b/src/nocrypto.mli
@@ -177,6 +177,9 @@ module Hash : sig
     val init : unit -> t
     (** Create a new hash state. *)
 
+    val dup : t -> t
+    (** Create a deep copy of a hash state. *)
+
     val feed : t -> Cstruct.t -> unit
     (** Hash the input, updating the state. *)
 


### PR DESCRIPTION
There are several protocols (e.g. tor) which require to (a) finalize the hash and transmit parts of it, and (b) continue to feed the hash function for the next message.

Other applications, such as OpenPGP, as well require you to hash data, take some bytes, hash some more, take some more bytes, hash some more, and finally sign the hash.