### PR TITLE
build system housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,18 @@ script: bash -ex .travis-opam.sh
 env:
   global:
     - PACKAGE="nocrypto"
-    - PINS="depext:0.9.1 mirage-os-shim:git://github.com/pqwy/mirage-os-shim.git mirage-unix:git://github.com/mirage/mirage-platform.git mirage-xen:git://github.com/mirage/mirage-platform.git"
     - UPDATE_GCC_BINUTILS=1
   matrix:
     - OCAML_VERSION=4.02
-    - OCAML_VERSION=4.02 DEPOPTS=lwt
-    - OCAML_VERSION=4.02 DEPOPTS=mirage-xen TESTS=false
+    - OCAML_VERSION=4.02 DEPOPTS="lwt cstruct-lwt"
+    - OCAML_VERSION=4.02 DEPOPTS="mirage-entropy" TESTS=false
     - OCAML_VERSION=4.03
-    - OCAML_VERSION=4.03 DEPOPTS=lwt
-    - OCAML_VERSION=4.03 DEPOPTS=mirage-xen TESTS=false
+    - OCAML_VERSION=4.03 DEPOPTS="lwt cstruct-lwt"
     - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.04 DEPOPTS=lwt
-    - OCAML_VERSION=4.04 DEPOPTS=mirage-xen TESTS=false
+    - OCAML_VERSION=4.04 DEPOPTS="lwt cstruct-lwt"
+    - OCAML_VERSION=4.04 DEPOPTS="mirage-xen" TESTS=false
     - OCAML_VERSION=4.05
-    - OCAML_VERSION=4.05 DEPOPTS=lwt
-    - OCAML_VERSION=4.05 DEPOPTS=mirage-xen TESTS=false
+    - OCAML_VERSION=4.05 DEPOPTS="lwt cstruct-lwt"
+    - OCAML_VERSION=4.05 DEPOPTS="mirage-solo5 mirage-entropy" TESTS=false
 notifications:
   email: false

--- a/opam
+++ b/opam
@@ -10,9 +10,9 @@ tags:          [ "org:mirage" ]
 available:     [ ocaml-version >= "4.02.0" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
-                "--with-lwt" "%{lwt:installed}%"
+                "--with-lwt" "%{lwt+cstruct-lwt:installed}%"
                 "--xen" "%{mirage-xen:installed}%"
-                "--mirage" "%{mirage-entropy:installed}%"
+                "--mirage" "%{mirage-entropy+lwt:installed}%"
                 "--freestanding" "%{mirage-solo5:installed}%"]
 
 depends: [
@@ -24,16 +24,18 @@ depends: [
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ounit" {test}
-  "cstruct" {>="2.4.0"}
-  "cstruct-lwt"
+  "cstruct" {>="3.0.0"}
   "zarith"
-  "lwt"
   "sexplib"
   ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding"))
 ]
 
-depopts: ["mirage-entropy"]
+depopts: [
+  "mirage-entropy"
+  "cstruct-lwt"
+  "lwt"
+]
 
 conflicts: [
   "topkg" {<"0.8.0"}

--- a/pkg/META
+++ b/pkg/META
@@ -23,7 +23,7 @@ package "unix" (
 package "lwt" (
  version = "%%VERSION_NUM%%"
  description = "Simple crypto for the modern age"
- requires = "nocrypto nocrypto.unix lwt.unix cstruct.lwt"
+ requires = "nocrypto nocrypto.unix lwt.unix cstruct-lwt"
  archive(byte) = "nocrypto_lwt.cma"
  archive(native) = "nocrypto_lwt.cmxa"
  plugin(byte) = "nocrypto_lwt.cma"


### PR DESCRIPTION
- lwt and cstruct-lwt are an optional dependency again
- use cstruct-lwt in META instead of cstruct.lwt - requires >= cstruct.3.0.0
- build lwt subdirectory only if both lwt and cstruct-lwt are present