### PR TITLE
depopt mirage-entropy in 4.03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ env:
     - OCAML_VERSION=4.02 DEPOPTS="lwt cstruct-lwt"
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.03 DEPOPTS="lwt cstruct-lwt"
-    - OCAML_VERSION=4.03 DEPOPTS="mirage-entropy" TESTS=false
+    - OCAML_VERSION=4.03 DEPOPTS="mirage-entropy"
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.04 DEPOPTS="lwt cstruct-lwt"
-    - OCAML_VERSION=4.04 DEPOPTS="mirage-xen" TESTS=false
+    - OCAML_VERSION=4.04 DEPOPTS="mirage-xen"
     - OCAML_VERSION=4.05
     - OCAML_VERSION=4.05 DEPOPTS="lwt cstruct-lwt"
-    - OCAML_VERSION=4.05 DEPOPTS="mirage-solo5 mirage-entropy" TESTS=false
+    - OCAML_VERSION=4.05 DEPOPTS="mirage-solo5 mirage-entropy"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
   matrix:
     - OCAML_VERSION=4.02
     - OCAML_VERSION=4.02 DEPOPTS="lwt cstruct-lwt"
-    - OCAML_VERSION=4.02 DEPOPTS="mirage-entropy" TESTS=false
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.03 DEPOPTS="lwt cstruct-lwt"
+    - OCAML_VERSION=4.03 DEPOPTS="mirage-entropy" TESTS=false
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.04 DEPOPTS="lwt cstruct-lwt"
     - OCAML_VERSION=4.04 DEPOPTS="mirage-xen" TESTS=false


### PR DESCRIPTION
excuse my error in the previous PR... but MirageOS is no longer 4.02.* compatible...