### PR TITLE
Fix compilation on BSD and MacOSX

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true: color(always)
 true: bin_annot, safe_string
 true: warn(A-4-29-33-40-41-42-43-34-44-48)
-true: package(bytes cstruct)
+true: package(bytes cstruct ocplib-endian ocplib-endian.bigstring)
 
 <src>: include
 <src/*.ml{,i}>: package(zarith sexplib ppx_sexp_conv)

--- a/opam
+++ b/opam
@@ -25,6 +25,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "ounit" {test}
   "cstruct" {>="3.0.0" & <"3.2.0"}
+  "ocplib-endian"
   "zarith"
   "sexplib"
   ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))

--- a/src/native/nocrypto.h
+++ b/src/native/nocrypto.h
@@ -3,7 +3,15 @@
 
 #include <stdint.h>
 #define __USE_MISC
+
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/endian.h>
+#elif defined(__APPLE__)
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
+
 #include <caml/mlvalues.h>
 #include <caml/bigarray.h>
 


### PR DESCRIPTION
and also declare the dependency to `ocplib-endian` explicitly