### PR TITLE
Provide betole|letobe macros on OS X.

### DIFF
--- a/src/native/nocrypto.h
+++ b/src/native/nocrypto.h
@@ -5,7 +5,21 @@
 #if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #elif defined(__APPLE__)
+/* OS X endian.h doesn't provide be|le macros  */
 #include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
 #else
 // Needs _DEFAULT_SOURCE on Linux.
 #include <endian.h>


### PR DESCRIPTION
OS X endian.h doesn't define betole|letobe functions. It's also not optional
depending on a #define, it's really not there. This seems to be the common
solution people adopt.

This change adds all macros, even ones that are not used by nocrypto to match
endian.h on other systems, otherwise this problem will pop up again once another
betole/letobe function is used.

It was broken on the cpu_to_* conversion on commit:
commit 555d2fe99b32481801bbfeb346b0b87dc122c7c0
Author: pqwy <david@numm.org>
Date:   Sat Dec 9 21:41:17 2017 -0500

    uncrap counters