### PR TITLE
Pass -thread flag

### DIFF
--- a/_tags
+++ b/_tags
@@ -4,7 +4,7 @@ true: warn(A-4-29-33-40-41-42-43-34-44-48)
 true: package(bytes cstruct)
 
 <src>: include
-<src/*.ml{,i}>: package(zarith sexplib ppx_sexp_conv)
+<src/*.ml{,i}>: package(zarith sexplib ppx_sexp_conv ocplib-endian)
 <src/*.cm{x,o}> and not <src/nocrypto.cmx>: for-pack(Nocrypto)
 <src/*.cm{,x}a>: link_stubs(src/libnocrypto_stubs)
 
@@ -12,7 +12,7 @@ true: package(bytes cstruct)
 <unix/*.ml{,i}>: package(unix bytes)
 
 <lwt>: include
-<lwt/*.ml{,i}>: package(lwt.unix cstruct.lwt)
+<lwt/*.ml{,i}>: package(lwt.unix cstruct.lwt), thread
 
 <mirage>: include
 <mirage/*.ml{,i}>: package(lwt mirage-entropy)
@@ -20,7 +20,7 @@ true: package(bytes cstruct)
 <**/*.c>: ccopt(-D_DEFAULT_SOURCE --std=c99 -Wall -Wextra -O3)
 <**/aes_aesni.c>: ccopt(-Wno-implicit-fallthrough)
 
-<bench/*>: use_nocrypto, package(zarith)
-<tests/*>: use_nocrypto, package(zarith oUnit)
+<bench/*>: use_nocrypto, package(zarith ocplib-endian)
+<tests/*>: use_nocrypto, package(zarith oUnit ocplib-endian)
 
 <rondom>: -traverse

--- a/opam
+++ b/opam
@@ -26,11 +26,13 @@ depends: [
   "cpuid" {build}
   "ocb-stubblr" {build}
   "ppx_deriving" {build}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv" {build & < "v0.11.0"}
   "ounit" {test}
   "cstruct" {>="3.0.0" & <"3.3.0"}
+  "cstruct-lwt"
   "zarith"
-  "sexplib"
+  "lwt"
+  "sexplib" {< "v0.11.0"}
   "ocplib-endian"
   ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding"))
@@ -43,7 +45,7 @@ depopts: [
 ]
 
 conflicts: [
-  "topkg" {<"0.8.0"}
+  "topkg" {<"0.9.1"}
   "ocb-stubblr" {<"0.1.0"}
   "mirage-xen" {<"2.2.0"}
   "sexplib" {="v0.9.0"}

--- a/opam
+++ b/opam
@@ -31,6 +31,7 @@ depends: [
   "cstruct" {>="3.0.0" & <"3.2.0"}
   "zarith"
   "sexplib"
+  "ocplib-endian"
   ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding"))
 ]

--- a/opam
+++ b/opam
@@ -28,7 +28,7 @@ depends: [
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "ounit" {test}
-  "cstruct" {>="3.0.0" & <"3.2.0"}
+  "cstruct" {>="3.0.0" & <"3.3.0"}
   "zarith"
   "sexplib"
   "ocplib-endian"

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Simple crypto for the modern age"
-requires = "cstruct zarith sexplib"
+requires = "cstruct zarith sexplib ocplib-endian"
 archive(byte) = "nocrypto.cma"
 archive(native) = "nocrypto.cmxa"
 plugin(byte) = "nocrypto.cma"


### PR DESCRIPTION
This is required by recent Lwt. See https://github.com/ocsigen/lwt/commit/f6e0117685f575e9b765cff20005b56b14a29620

Additionally, recent master depends on `ocplib-endian` for the `EndianBytes` module.