### PR TITLE
Auto-detect ppx_sexp_conv runtime dependencies

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,5 +1,24 @@
 open Ocamlbuild_plugin
 
-let () = dispatch Ocb_stubblr.(
-  init & ccopt ~tags:["accelerate"] "-DACCELERATE -mssse3 -maes -mpclmul"
-)
+let runtime_deps_of_ppx ppx =
+  (Findlib.query "ppx_sexp_conv").dependencies
+  |> List.filter_opt (fun { Findlib.name; _ } ->
+      if name = ppx || name = "ppx_deriving" then
+        None
+      else
+        Some name)
+
+let () = dispatch (fun hook ->
+    Ocb_stubblr.(
+      init & ccopt ~tags:["accelerate"] "-DACCELERATE -mssse3 -maes -mpclmul"
+    ) hook;
+    match hook with
+    | After_rules ->
+      let meta = "pkg/META" in
+      let meta_in = meta ^ ".in" in
+      rule meta ~dep:meta_in ~prod:meta (fun _ _ ->
+          let deps = String.concat " " (runtime_deps_of_ppx "ppx_sexp_conv") in
+          Echo([String.subst "PPX_SEXP_CONV_RUNTIME" deps
+                  (Pathname.read meta_in)],
+               meta))
+    | _ -> ())

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Simple crypto for the modern age"
-requires = "cstruct zarith sexplib"
+requires = "cstruct zarith sexplib PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "nocrypto.cma"
 archive(native) = "nocrypto.cmxa"
 plugin(byte) = "nocrypto.cma"


### PR DESCRIPTION
This PR allows to automatically detect the runtime dependencies of `ppx_sexp_conv` in order to store them in the META file. This allows ocaml-nocrypto to be compatible with both `ppx_sexp_conv` < v0.11 and >= v0.11.

The method used should work with any ppx rewriter, not just ppx_sexp_conv.