### PR TITLE
Support cstruct +3.4.0

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true: color(always)
 true: bin_annot, safe_string
 true: warn(A-4-29-33-40-41-42-43-34-44-48)
-true: package(bytes ocplib-endian cstruct)
+true: package(bytes ocplib-endian sexplib cstruct)
 
 <src>: include
 <src/*.ml{,i}>: package(zarith)

--- a/_tags
+++ b/_tags
@@ -12,7 +12,7 @@ true: package(bytes ocplib-endian cstruct)
 <unix/*.ml{,i}>: package(unix)
 
 <lwt>: include
-<lwt/*.ml{,i}>: package(lwt.unix cstruct.lwt)
+<lwt/*.ml{,i}>: package(lwt.unix cstruct-lwt)
 
 <mirage>: include
 <mirage/*.ml{,i}>: package(lwt mirage-entropy)

--- a/opam
+++ b/opam
@@ -26,7 +26,7 @@ depends: [
   "cpuid" {build}
   "ocb-stubblr" {build}
   "ounit" {test}
-  "cstruct" {>="3.0.0" & <"3.4.0"}
+  "cstruct" {>="3.0.0" & <"4.0.0"}
   "ocplib-endian"
   "zarith"
   ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))

--- a/opam
+++ b/opam
@@ -26,8 +26,9 @@ depends: [
   "cpuid" {build}
   "ocb-stubblr" {build}
   "ounit" {test}
-  "cstruct" {>="3.0.0" & <"4.0.0"}
+  "cstruct" {>="3.0.0"}
   "ocplib-endian"
+  "sexplib"
   "zarith"
   ("mirage-no-xen" | ("mirage-xen" & "zarith-xen"))
   ("mirage-no-solo5" | ("mirage-solo5" & "zarith-freestanding"))


### PR DESCRIPTION
Build using cstruct-lwt instead of cstruct.lwt, as per instructions on https://discuss.ocaml.org/t/psa-cstruct-3-4-0-removes-old-ocamlfind-subpackage-aliases/3275

Fixes https://github.com/mirleft/ocaml-nocrypto/issues/155