### PR TITLE
Look for CFLAGS when building with dune

### DIFF
--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -9,4 +9,10 @@ let _ =
   | "false" -> []
   | _ -> auto
   | exception Not_found -> auto in
+  let cflags = match Sys.getenv_opt "CFLAGS" with
+  | Some cflags -> [ cflags ]
+  | None -> []
+  in
+  let fs = fs @ cflags in
   Format.(printf "(@[%a@])%!" (fun ppf -> List.iter (fprintf ppf "%s@ ")) fs)
+  


### PR DESCRIPTION
Look for CFLAGS and apply them if they exist. The reason I need this is because Windows doesn't supply endian.h so I want to supply it myself.